### PR TITLE
Rename gschema

### DIFF
--- a/hwangsae/org.hwangsaeul.hwangsae.gschema.xml
+++ b/hwangsae/org.hwangsaeul.hwangsae.gschema.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
-  <schema id="org.hwangsaeul.hwangsae" path="/org/hwangsaeul/hwangsae/">
+  <schema id="org.hwangsaeul.hwangsae.recorder" path="/org/hwangsaeul/hwangsae/recorder/">
     <key name="recording-dir" type="s">
       <default>""</default>
       <summary>Recording directory</summary>

--- a/hwangsae/recorder.c
+++ b/hwangsae/recorder.c
@@ -247,7 +247,7 @@ hwangsae_recorder_init (HwangsaeRecorder * self)
 {
   HwangsaeRecorderPrivate *priv = hwangsae_recorder_get_instance_private (self);
 
-  priv->settings = g_settings_new ("org.hwangsaeul.hwangsae");
+  priv->settings = g_settings_new ("org.hwangsaeul.hwangsae.recorder");
 
   g_settings_bind (priv->settings, "recording-dir", self, "recording-dir",
       G_SETTINGS_BIND_DEFAULT);


### PR DESCRIPTION
Another object, relay, is going to be ready to get reviewed. IMO, independent service should have its own schema.