### PR TITLE
relay: M:N connectivity

### DIFF
--- a/agent/agent.c
+++ b/agent/agent.c
@@ -54,8 +54,6 @@ hwangsae_agent_dbus_register (GApplication * app,
 
   g_debug ("hwangsae_agent_dbus_register");
 
-  g_application_hold (app);
-
   /* chain up */
   ret =
       G_APPLICATION_CLASS (hwangsae_agent_parent_class)->dbus_register


### PR DESCRIPTION
Sinks and sources are matched based on Username and Resource keys
respectively found in their SRT Stream IDs.

Since we don't have any source nodes that support SRT Stream IDs, source
connections without it are still allowed for now. When a source doesn't
send any ID, it gets paired with the first available sink.

