### PR TITLE
Add relay tests

### DIFF
--- a/agent/meson.build
+++ b/agent/meson.build
@@ -16,9 +16,8 @@ foreach agent: agents
     src_file,
     install: true,
     include_directories: hwangsae_incs,
-    dependencies : [ libgaeguli_dep ],
     c_args: [ hwangsae_agent_c_args, ],
-  dependencies: [ gobject_dep, gio_dep, libhwangsae_dbus_dep, libhwangsae_dep, chamge_dep ],
+    dependencies: [ libhwangsae_dbus_dep, libhwangsae_dep, chamge_dep ],
   )
 
 endforeach

--- a/hwangsae/relay.c
+++ b/hwangsae/relay.c
@@ -69,6 +69,7 @@ struct _HwangsaeRelay
   guint source_port;
 
   gchar *sink_uri;
+  gchar *source_uri;
 
   SRTSOCKET sink_listen_sock;
   SRTSOCKET source_listen_sock;
@@ -131,6 +132,7 @@ hwangsae_relay_finalize (GObject * object)
   g_mutex_clear (&self->lock);
 
   g_clear_pointer (&self->sink_uri, g_free);
+  g_clear_pointer (&self->source_uri, g_free);
 
   srt_close (self->sink_listen_sock);
   srt_close (self->source_listen_sock);
@@ -552,14 +554,30 @@ _get_local_ip (void)
   return result;
 }
 
+static gchar *
+_make_uri_with_port (guint port)
+{
+  g_autofree gchar *ip = _get_local_ip ();
+
+  return g_strdup_printf ("srt://%s:%d", ip, port);
+}
+
 const gchar *
 hwangsae_relay_get_sink_uri (HwangsaeRelay * self)
 {
   if (!self->sink_uri) {
-    g_autofree gchar *ip = _get_local_ip ();
-
-    self->sink_uri = g_strdup_printf ("srt://%s:%d", ip, self->sink_port);
+    self->sink_uri = _make_uri_with_port (self->sink_port);
   }
 
   return self->sink_uri;
+}
+
+const gchar *
+hwangsae_relay_get_source_uri (HwangsaeRelay * self)
+{
+  if (!self->source_uri) {
+    self->source_uri = _make_uri_with_port (self->source_port);
+  }
+
+  return self->source_uri;
 }

--- a/hwangsae/relay.h
+++ b/hwangsae/relay.h
@@ -35,6 +35,8 @@ HwangsaeRelay          *hwangsae_relay_new              (void);
 
 const gchar            *hwangsae_relay_get_sink_uri     (HwangsaeRelay *relay);
 
+const gchar            *hwangsae_relay_get_source_uri   (HwangsaeRelay *relay);
+
 G_END_DECLS
 
 #endif // __HWANGSAE_RELAY_H__

--- a/tests/common/meson.build
+++ b/tests/common/meson.build
@@ -1,0 +1,11 @@
+sources = [
+  'test-streamer.c',
+]
+
+libhwangsae_test_common = library(
+  'hwangsae-test-common',
+  sources,
+  dependencies: [ gaeguli_dep ],
+  c_args: test_c_args,
+  install: false
+)

--- a/tests/common/test-streamer.c
+++ b/tests/common/test-streamer.c
@@ -45,6 +45,7 @@ G_DEFINE_TYPE (HwangsaeTestStreamer, hwangsae_test_streamer, G_TYPE_OBJECT)
 enum
 {
   PROP_RESOLUTION = 1,
+  PROP_USERNAME,
   PROP_LAST
 };
 
@@ -136,6 +137,21 @@ hwangsae_test_streamer_init (HwangsaeTestStreamer * self)
 }
 
 static void
+hwangsae_test_streamer_get_property (GObject * object, guint prop_id,
+    GValue * value, GParamSpec * pspec)
+{
+  HwangsaeTestStreamer *self = HWANGSAE_TEST_STREAMER (object);
+
+  switch (prop_id) {
+    case PROP_USERNAME:
+      g_value_set_string (value, self->username);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+  }
+}
+
+static void
 hwangsae_test_streamer_set_property (GObject * object, guint prop_id,
     const GValue * value, GParamSpec * pspec)
 {
@@ -172,6 +188,7 @@ hwangsae_test_streamer_class_init (HwangsaeTestStreamerClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
 
+  gobject_class->get_property = hwangsae_test_streamer_get_property;
   gobject_class->set_property = hwangsae_test_streamer_set_property;
   gobject_class->dispose = hwangsae_test_streamer_dispose;
 
@@ -179,6 +196,10 @@ hwangsae_test_streamer_class_init (HwangsaeTestStreamerClass * klass)
       g_param_spec_enum ("resolution", "Video resolution", "Video resolution",
           GAEGULI_TYPE_VIDEO_RESOLUTION, GAEGULI_VIDEO_RESOLUTION_640X480,
           G_PARAM_WRITABLE | G_PARAM_CONSTRUCT | G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (gobject_class, PROP_USERNAME,
+      g_param_spec_string ("username", "SRT username", "SRT username",
+          NULL, G_PARAM_READABLE | G_PARAM_STATIC_STRINGS));
 }
 
 HwangsaeTestStreamer *

--- a/tests/common/test-streamer.c
+++ b/tests/common/test-streamer.c
@@ -1,0 +1,131 @@
+/** 
+ *  tests/common
+ *
+ *  Copyright 2019 SK Telecom Co., Ltd.
+ *    Author: Jakub Adam <jakub.adam@collabora.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#include "test-streamer.h"
+
+#include <gaeguli/gaeguli.h>
+
+struct _HwangsaeTestStreamer
+{
+  GObject parent;
+
+  GaeguliFifoTransmit *transmit;
+  GaeguliPipeline *pipeline;
+
+  gboolean should_stream;
+  GThread *streaming_thread;
+};
+
+/* *INDENT-OFF* */
+G_DEFINE_TYPE (HwangsaeTestStreamer, hwangsae_test_streamer, G_TYPE_OBJECT)
+/* *INDENT-ON* */
+
+static gboolean
+hwangsae_test_streamer_thread_func (HwangsaeTestStreamer * self)
+{
+  g_autoptr (GMainContext) context = g_main_context_new ();
+  g_autoptr (GError) error = NULL;
+  guint transmit_id;
+
+  g_main_context_push_thread_default (context);
+
+  transmit_id = gaeguli_fifo_transmit_start (self->transmit,
+      "127.0.0.1", 8888, GAEGULI_SRT_MODE_LISTENER, &error);
+  g_assert_no_error (error);
+
+  while (self->should_stream) {
+    g_main_context_iteration (context, TRUE);
+  }
+
+  gaeguli_fifo_transmit_stop (self->transmit, transmit_id, &error);
+  g_assert_no_error (error);
+
+  return TRUE;
+}
+
+void
+hwangsae_test_streamer_start (HwangsaeTestStreamer * self)
+{
+  g_assert_null (self->streaming_thread);
+
+  self->should_stream = TRUE;
+  self->streaming_thread = g_thread_new ("streaming_thread_func",
+      (GThreadFunc) hwangsae_test_streamer_thread_func, self);
+}
+
+void
+hwangsae_test_streamer_pause (HwangsaeTestStreamer * self)
+{
+  self->should_stream = FALSE;
+  g_clear_pointer (&self->streaming_thread, g_thread_join);
+}
+
+void
+hwangsae_test_streamer_stop (HwangsaeTestStreamer * self)
+{
+  gaeguli_pipeline_stop (self->pipeline);
+  hwangsae_test_streamer_pause (self);
+}
+
+static void
+hwangsae_test_streamer_init (HwangsaeTestStreamer * self)
+{
+  g_autoptr (GError) error = NULL;
+
+  self->transmit = gaeguli_fifo_transmit_new ();
+  self->pipeline = gaeguli_pipeline_new_full (GAEGULI_VIDEO_SOURCE_VIDEOTESTSRC,
+      NULL, GAEGULI_ENCODING_METHOD_GENERAL);
+
+  g_object_set (self->pipeline, "clock-overlay", TRUE, NULL);
+
+  gaeguli_pipeline_add_fifo_target_full (self->pipeline,
+      GAEGULI_VIDEO_CODEC_H264, GAEGULI_VIDEO_RESOLUTION_640X480,
+      gaeguli_fifo_transmit_get_fifo (self->transmit), &error);
+  g_assert_no_error (error);
+}
+
+static void
+hwangsae_test_streamer_dispose (GObject * object)
+{
+  HwangsaeTestStreamer *self = HWANGSAE_TEST_STREAMER (object);
+
+  if (self->should_stream) {
+    hwangsae_test_streamer_stop (self);
+  }
+
+  g_clear_object (&self->transmit);
+  g_clear_object (&self->pipeline);
+
+  G_OBJECT_CLASS (hwangsae_test_streamer_parent_class)->dispose (object);
+}
+
+static void
+hwangsae_test_streamer_class_init (HwangsaeTestStreamerClass * klass)
+{
+  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+
+  gobject_class->dispose = hwangsae_test_streamer_dispose;
+}
+
+HwangsaeTestStreamer *
+hwangsae_test_streamer_new (void)
+{
+  return g_object_new (HWANGSAE_TYPE_TEST_STREAMER, NULL);
+}

--- a/tests/common/test-streamer.c
+++ b/tests/common/test-streamer.c
@@ -28,6 +28,7 @@ struct _HwangsaeTestStreamer
   GObject parent;
 
   gchar *uri;
+  gchar *username;
 
   GaeguliFifoTransmit *transmit;
   GaeguliPipeline *pipeline;
@@ -62,8 +63,9 @@ hwangsae_test_streamer_thread_func (HwangsaeTestStreamer * self)
   }
   g_assert (mode != GAEGULI_SRT_MODE_UNKNOWN);
 
-  transmit_id = gaeguli_fifo_transmit_start (self->transmit,
-      gst_uri_get_host (uri), gst_uri_get_port (uri), mode, &error);
+  transmit_id = gaeguli_fifo_transmit_start_full (self->transmit,
+      gst_uri_get_host (uri), gst_uri_get_port (uri), mode, self->username,
+      &error);
   g_assert_no_error (error);
 
   while (self->should_stream) {
@@ -113,6 +115,7 @@ hwangsae_test_streamer_init (HwangsaeTestStreamer * self)
   g_autoptr (GError) error = NULL;
 
   self->uri = g_strdup ("srt://127.0.0.1:8888?mode=listener");
+  self->username = g_strdup_printf ("HwangsaeTestStreamer %p", self);
   self->transmit = gaeguli_fifo_transmit_new ();
   self->pipeline = gaeguli_pipeline_new_full (GAEGULI_VIDEO_SOURCE_VIDEOTESTSRC,
       NULL, GAEGULI_ENCODING_METHOD_GENERAL);
@@ -135,6 +138,7 @@ hwangsae_test_streamer_dispose (GObject * object)
   }
 
   g_clear_pointer (&self->uri, g_free);
+  g_clear_pointer (&self->username, g_free);
   g_clear_object (&self->transmit);
   g_clear_object (&self->pipeline);
 

--- a/tests/common/test-streamer.h
+++ b/tests/common/test-streamer.h
@@ -28,10 +28,12 @@ G_BEGIN_DECLS
 #define HWANGSAE_TYPE_TEST_STREAMER     (hwangsae_test_streamer_get_type ())
 G_DECLARE_FINAL_TYPE                    (HwangsaeTestStreamer, hwangsae_test_streamer, HWANGSAE, TEST_STREAMER, GObject)
 
-HwangsaeTestStreamer * hwangsae_test_streamer_new   (void);
-void                   hwangsae_test_streamer_start (HwangsaeTestStreamer * self);
-void                   hwangsae_test_streamer_pause (HwangsaeTestStreamer * self);
-void                   hwangsae_test_streamer_stop  (HwangsaeTestStreamer * self);
+HwangsaeTestStreamer * hwangsae_test_streamer_new     (void);
+void                   hwangsae_test_streamer_set_uri (HwangsaeTestStreamer * self,
+                                                       const gchar *uri);
+void                   hwangsae_test_streamer_start   (HwangsaeTestStreamer * self);
+void                   hwangsae_test_streamer_pause   (HwangsaeTestStreamer * self);
+void                   hwangsae_test_streamer_stop    (HwangsaeTestStreamer * self);
 
 G_END_DECLS
 

--- a/tests/common/test-streamer.h
+++ b/tests/common/test-streamer.h
@@ -1,0 +1,38 @@
+/** 
+ *  tests/test-streamer
+ *
+ *  Copyright 2019 SK Telecom Co., Ltd.
+ *    Author: Jakub Adam <jakub.adam@collabora.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+#ifndef __HWANGSAE_TEST_STREAMER_H__
+#define __HWANGSAE_TEST_STREAMER_H__
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define HWANGSAE_TYPE_TEST_STREAMER     (hwangsae_test_streamer_get_type ())
+G_DECLARE_FINAL_TYPE                    (HwangsaeTestStreamer, hwangsae_test_streamer, HWANGSAE, TEST_STREAMER, GObject)
+
+HwangsaeTestStreamer * hwangsae_test_streamer_new   (void);
+void                   hwangsae_test_streamer_start (HwangsaeTestStreamer * self);
+void                   hwangsae_test_streamer_pause (HwangsaeTestStreamer * self);
+void                   hwangsae_test_streamer_stop  (HwangsaeTestStreamer * self);
+
+G_END_DECLS
+
+#endif /* __HWANGSAE_TEST_STREAMER_H__ */

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,3 +1,7 @@
+test_c_args = '-DG_LOG_DOMAIN="hwangsae-tests"'
+
+subdir('common')
+
 tests = [
   'test-recorder',
   'test-relay',
@@ -16,8 +20,9 @@ foreach t: tests
 
   exe = executable(
     t, ['@0@.c'.format(t), hwangsae_schemas],
-    c_args: '-DG_LOG_DOMAIN="hwangsae-tests"',
+    c_args: test_c_args,
     include_directories: hwangsae_incs,
+    link_with: libhwangsae_test_common,
     dependencies: [ libhwangsae_dep, gaeguli_dep, gstreamer_pbutils_dep ],
     install: false,
   )

--- a/tests/test-relay.c
+++ b/tests/test-relay.c
@@ -19,6 +19,9 @@
  */
 
 #include "hwangsae/hwangsae.h"
+#include "common/test-streamer.h"
+
+#include <gst/pbutils/gstdiscoverer.h>
 
 static void
 test_hwangsae_relay_instance (void)
@@ -35,6 +38,73 @@ test_hwangsae_relay_instance (void)
   g_assert_cmpint (source_port, ==, 9999);
 }
 
+typedef struct
+{
+  GMainLoop *loop;
+  const gchar *source_uri;
+
+  guint num_validated_connections;
+} TestData1ToN;
+
+static gboolean
+validate_stream (TestData1ToN * data)
+{
+  g_autoptr (GstDiscoverer) discoverer = NULL;
+  g_autoptr (GstDiscovererInfo) info = NULL;
+  g_autoptr (GstDiscovererStreamInfo) stream_info = NULL;
+  g_autoptr (GstCaps) stream_caps = NULL;
+  g_autoptr (GError) error = NULL;
+  g_autofree gchar *stream_caps_str = NULL;
+
+  discoverer = gst_discoverer_new (20 * GST_SECOND, &error);
+  g_assert_no_error (error);
+
+  info = gst_discoverer_discover_uri (discoverer, data->source_uri, &error);
+  g_assert_no_error (error);
+  g_assert_cmpint (gst_discoverer_info_get_result (info), ==,
+      GST_DISCOVERER_OK);
+
+  stream_info = gst_discoverer_info_get_stream_info (info);
+  stream_caps = gst_discoverer_stream_info_get_caps (stream_info);
+
+  stream_caps_str = gst_caps_to_string (stream_caps);
+  g_debug ("Stream has caps: %s", stream_caps_str);
+
+  g_assert_cmpint (gst_caps_get_size (stream_caps), ==, 1);
+  g_assert_cmpstr
+      (gst_structure_get_name (gst_caps_get_structure (stream_caps, 0)), ==,
+      "video/mpegts");
+
+  if (++data->num_validated_connections == 2) {
+    g_main_loop_quit (data->loop);
+  }
+
+  return G_SOURCE_REMOVE;
+}
+
+static void
+test_hwangsae_1_to_n (void)
+{
+  g_autoptr (HwangsaeTestStreamer) streamer = hwangsae_test_streamer_new ();
+  g_autoptr (HwangsaeRelay) relay = hwangsae_relay_new ();
+  TestData1ToN data = { 0 };
+
+  data.loop = g_main_loop_new (NULL, FALSE);
+  data.source_uri = hwangsae_relay_get_source_uri (relay);
+
+  hwangsae_test_streamer_set_uri (streamer,
+      hwangsae_relay_get_sink_uri (relay));
+  hwangsae_test_streamer_start (streamer);
+
+  /* Connect and validate two receivers. */
+  g_idle_add ((GSourceFunc) validate_stream, &data);
+  g_idle_add ((GSourceFunc) validate_stream, &data);
+
+  g_main_loop_run (data.loop);
+
+  g_clear_pointer (&data.loop, g_main_loop_unref);
+}
+
 int
 main (int argc, char *argv[])
 {
@@ -44,6 +114,7 @@ main (int argc, char *argv[])
   g_log_set_always_fatal (G_LOG_FATAL_MASK | G_LOG_LEVEL_CRITICAL);
 
   g_test_add_func ("/hwangsae/relay-instance", test_hwangsae_relay_instance);
+  g_test_add_func ("/hwangsae/relay-1-to-n", test_hwangsae_1_to_n);
 
   return g_test_run ();
 }


### PR DESCRIPTION
**1 to N test**
Starts the relay, connects SRT sender to its sink, then connects two receivers and validates the received streams.

**M to N test**
Connects two sinks to the relay with SRT Usernames A and B, then
connects two sources requesting sink A and B respectively. Checks that
each source receives stream from its requested sink.

Needs https://github.com/hwangsaeul/gst-plugins-bad/pull/1 for successful execution.
