### PR TITLE
relay: allow setting external IP address for connections

### DIFF
--- a/tests/test-recorder.c
+++ b/tests/test-recorder.c
@@ -163,7 +163,7 @@ stream_disconnected_cb (HwangsaeRecorder * recorder, TestFixture * fixture)
 }
 
 static void
-test_hwangsae_recorder_record (TestFixture * fixture, gconstpointer data)
+test_recorder_record (TestFixture * fixture, gconstpointer data)
 {
   HwangsaeContainer container = GPOINTER_TO_INT (data);
   RecorderTestData test_data = { 0 };
@@ -355,7 +355,7 @@ first_segment_started_cb (HwangsaeRecorder * recorder, TestFixture * fixture)
 }
 
 static void
-test_hwangsae_recorder_disconnect (TestFixture * fixture, gconstpointer unused)
+test_recorder_disconnect (TestFixture * fixture, gconstpointer unused)
 {
   g_signal_connect (fixture->recorder, "stream-connected",
       (GCallback) first_segment_started_cb, fixture);
@@ -430,7 +430,7 @@ split_run_test (TestFixture * fixture)
 }
 
 static void
-test_hwangsae_recorder_split_time (TestFixture * fixture, gconstpointer unused)
+test_recorder_split_time (TestFixture * fixture, gconstpointer unused)
 {
   GSList *filenames;
   const GstClockTimeDiff FILE_SEGMENT_LEN = 5 * GST_SECOND;
@@ -457,7 +457,7 @@ test_hwangsae_recorder_split_time (TestFixture * fixture, gconstpointer unused)
 }
 
 static void
-test_hwangsae_recorder_split_bytes (TestFixture * fixture, gconstpointer unused)
+test_recorder_split_bytes (TestFixture * fixture, gconstpointer unused)
 {
   GSList *filenames;
   guint64 FILE_SEGMENT_LEN_BYTES = 5e6;
@@ -494,23 +494,23 @@ main (int argc, char *argv[])
 
   g_test_add ("/hwangsae/recorder-record-mp4",
       TestFixture, GUINT_TO_POINTER (HWANGSAE_CONTAINER_MP4), fixture_setup,
-      test_hwangsae_recorder_record, fixture_teardown);
+      test_recorder_record, fixture_teardown);
 
   g_test_add ("/hwangsae/recorder-record-ts",
       TestFixture, GUINT_TO_POINTER (HWANGSAE_CONTAINER_TS), fixture_setup,
-      test_hwangsae_recorder_record, fixture_teardown);
+      test_recorder_record, fixture_teardown);
 
   g_test_add ("/hwangsae/recorder-disconnect",
       TestFixture, NULL, fixture_setup,
-      test_hwangsae_recorder_disconnect, fixture_teardown);
+      test_recorder_disconnect, fixture_teardown);
 
   g_test_add ("/hwangsae/recorder-split-time",
       TestFixture, NULL, fixture_setup,
-      test_hwangsae_recorder_split_time, fixture_teardown);
+      test_recorder_split_time, fixture_teardown);
 
   g_test_add ("/hwangsae/recorder-split-bytes",
       TestFixture, NULL, fixture_setup,
-      test_hwangsae_recorder_split_bytes, fixture_teardown);
+      test_recorder_split_bytes, fixture_teardown);
 
   return g_test_run ();
 }

--- a/tests/test-relay.c
+++ b/tests/test-relay.c
@@ -25,7 +25,7 @@
 #include <gst/pbutils/gstdiscoverer.h>
 
 static void
-test_hwangsae_relay_instance (void)
+test_relay_instance (void)
 {
   guint sink_port, source_port;
   g_autoptr (HwangsaeRelay) relay = hwangsae_relay_new ();
@@ -113,7 +113,7 @@ validate_stream (RelayTestData * data)
 }
 
 static void
-test_hwangsae_1_to_n (void)
+test_1_to_n (void)
 {
   g_autoptr (HwangsaeTestStreamer) streamer = hwangsae_test_streamer_new ();
   g_autoptr (HwangsaeRelay) relay = hwangsae_relay_new ();
@@ -153,7 +153,7 @@ build_source_uri (HwangsaeTestStreamer * streamer, HwangsaeRelay * relay)
 }
 
 static void
-test_hwangsae_m_to_n (void)
+test_m_to_n (void)
 {
   g_autoptr (HwangsaeTestStreamer) streamer1 = hwangsae_test_streamer_new ();
   g_autoptr (HwangsaeTestStreamer) streamer2 = hwangsae_test_streamer_new ();
@@ -194,9 +194,9 @@ main (int argc, char *argv[])
   /* Don't treat warnings as fatal, which is GTest default. */
   g_log_set_always_fatal (G_LOG_FATAL_MASK | G_LOG_LEVEL_CRITICAL);
 
-  g_test_add_func ("/hwangsae/relay-instance", test_hwangsae_relay_instance);
-  g_test_add_func ("/hwangsae/relay-1-to-n", test_hwangsae_1_to_n);
-  g_test_add_func ("/hwangsae/relay-m-to-n", test_hwangsae_m_to_n);
+  g_test_add_func ("/hwangsae/relay-instance", test_relay_instance);
+  g_test_add_func ("/hwangsae/relay-1-to-n", test_1_to_n);
+  g_test_add_func ("/hwangsae/relay-m-to-n", test_m_to_n);
 
   return g_test_run ();
 }

--- a/tests/test-relay.c
+++ b/tests/test-relay.c
@@ -39,6 +39,26 @@ test_relay_instance (void)
   g_assert_cmpint (source_port, ==, 9999);
 }
 
+static void
+test_external_ip (void)
+{
+  static const gchar *EXTERNAL_IP = "10.1.2.3";
+  g_autoptr (HwangsaeRelay) relay = hwangsae_relay_new ();
+  g_autofree gchar *sink_uri = NULL;
+  g_autofree gchar *source_uri = NULL;
+  guint sink_port, source_port;
+
+  g_object_set (relay, "external-ip", EXTERNAL_IP, NULL);
+  g_object_get (relay, "sink-port", &sink_port, "source-port", &source_port,
+      NULL);
+
+  sink_uri = g_strdup_printf ("srt://%s:%d", EXTERNAL_IP, sink_port);
+  source_uri = g_strdup_printf ("srt://%s:%d", EXTERNAL_IP, source_port);
+
+  g_assert_cmpstr (hwangsae_relay_get_sink_uri (relay), ==, sink_uri);
+  g_assert_cmpstr (hwangsae_relay_get_source_uri (relay), ==, source_uri);
+}
+
 typedef struct
 {
   const gchar *source_uri;
@@ -195,6 +215,7 @@ main (int argc, char *argv[])
   g_log_set_always_fatal (G_LOG_FATAL_MASK | G_LOG_LEVEL_CRITICAL);
 
   g_test_add_func ("/hwangsae/relay-instance", test_relay_instance);
+  g_test_add_func ("/hwangsae/relay-external-ip", test_external_ip);
   g_test_add_func ("/hwangsae/relay-1-to-n", test_1_to_n);
   g_test_add_func ("/hwangsae/relay-m-to-n", test_m_to_n);
 


### PR DESCRIPTION
When "external-ip" property is set, the relay will use it in its source and sink URIs returned from hwangsae_relay_get_*_uri(). Otherwise, the first available non-loopback IP is used as before.

