### PR TITLE
recorder-agent: dbus api extension

### DIFF
--- a/agent/http-server.h
+++ b/agent/http-server.h
@@ -34,6 +34,14 @@ gchar                  *hwangsae_http_server_get_recording_dir (HwangsaeHttpServ
 void                    hwangsae_http_server_set_recording_dir (HwangsaeHttpServer *server,
                                                                 gchar              *recording_dir);
 
+gchar                  *hwangsae_http_server_get_url           (HwangsaeHttpServer *server,
+                                                                gchar              *edge_id,
+                                                                gchar              *file_id);
+
+gchar                  *hwangsae_http_server_check_file_path   (HwangsaeHttpServer *server,
+                                                                gchar              *edge_id,
+                                                                gchar              *file_id);
+
 G_END_DECLS
 
 #endif /* __HWANGSAE_HTTP_SERVER_H__ */

--- a/agent/recorder-agent.c
+++ b/agent/recorder-agent.c
@@ -492,6 +492,56 @@ gboolean
   return TRUE;
 }
 
+gboolean
+hwangsae_recorder_agent_recorder_interface_handle_url
+    (Hwangsae1DBusRecorderInterface * object,
+    GDBusMethodInvocation * invocation, gchar * arg_edge_id,
+    gchar * arg_file_id, gpointer user_data) {
+  HwangsaeRecorderAgent *self = (HwangsaeRecorderAgent *) user_data;
+  g_autofree gchar *cmd = NULL;
+  g_autofree gchar *response = NULL;
+  gchar *url = NULL;
+
+  g_debug ("hwangsae_recorder_agent_recorder_interface_handle_url");
+
+  url = hwangsae_http_server_get_url (self->hwangsae_http_server, arg_edge_id,
+      arg_file_id);
+
+  g_debug ("url: %s", url);
+
+  hwangsae1_dbus_recorder_interface_complete_url (object, invocation, url);
+
+  return TRUE;
+}
+
+gboolean
+hwangsae_recorder_agent_recorder_interface_handle_delete
+    (Hwangsae1DBusRecorderInterface * object,
+    GDBusMethodInvocation * invocation, gchar * arg_edge_id,
+    gchar * arg_file_id, gpointer user_data) {
+  HwangsaeRecorderAgent *self = (HwangsaeRecorderAgent *) user_data;
+  g_autofree gchar *cmd = NULL;
+  g_autofree gchar *response = NULL;
+  g_autofree gchar *filename = NULL;
+
+  g_debug ("hwangsae_recorder_agent_recorder_interface_handle_delete");
+
+  filename =
+      hwangsae_http_server_check_file_path (self->hwangsae_http_server,
+      arg_edge_id, arg_file_id);
+
+  if (filename) {
+    g_debug ("deleting file %s", filename);
+    g_remove (filename);
+  } else {
+    g_debug ("unable to delete file id %s, not found", arg_file_id);
+  }
+
+  hwangsae1_dbus_recorder_interface_complete_delete (object, invocation);
+
+  return TRUE;
+}
+
 static void
 hwangsae_recorder_agent_dispose (GObject * object)
 {
@@ -567,6 +617,13 @@ hwangsae_recorder_agent_init (HwangsaeRecorderAgent * self)
   g_signal_connect (self->recorder_interface, "handle-lookup-by-edge",
       G_CALLBACK
       (hwangsae_recorder_agent_recorder_interface_handle_lookup_by_edge), self);
+
+  g_signal_connect (self->recorder_interface, "handle-url",
+      G_CALLBACK (hwangsae_recorder_agent_recorder_interface_handle_url), self);
+
+  g_signal_connect (self->recorder_interface, "handle-delete",
+      G_CALLBACK
+      (hwangsae_recorder_agent_recorder_interface_handle_delete), self);
 
   hwangsae_recorder_set_container (self->recorder, HWANGSAE_CONTAINER_TS);
 }

--- a/hwangsae/common.c
+++ b/hwangsae/common.c
@@ -1,0 +1,68 @@
+/**
+ *  Copyright 2019 SK Telecom Co., Ltd.
+ *    Author: Walter Lozano <walter.lozano@collabora.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+#include <gio/gio.h>
+#include <errno.h>
+#include <ifaddrs.h>
+#include <net/if.h>
+#include <netdb.h>
+
+gchar *
+hwangsae_common_get_local_ip (void)
+{
+  struct ifaddrs *addrs;
+  struct ifaddrs *it;
+  gchar *result = NULL;
+
+  if (getifaddrs (&addrs) < 0) {
+    return NULL;
+  }
+
+  for (it = addrs; !result && it; it = it->ifa_next) {
+    socklen_t addr_len;
+    char buf[INET6_ADDRSTRLEN + 1];
+
+    /* Ignore interfaces that are down, not running or don't have an IP. We also
+     * want to skip loopbacks. */
+    if ((it->ifa_flags & (IFF_UP | IFF_RUNNING | IFF_LOOPBACK)) !=
+        (IFF_UP | IFF_RUNNING) || it->ifa_addr == NULL) {
+      continue;
+    }
+
+    switch (it->ifa_addr->sa_family) {
+      case AF_INET:
+        addr_len = sizeof (struct sockaddr_in);
+        break;
+      case AF_INET6:
+        addr_len = sizeof (struct sockaddr_in6);
+        break;
+      default:
+        continue;
+    }
+
+    if (getnameinfo (it->ifa_addr, addr_len, buf, sizeof (buf), NULL, 0,
+            NI_NUMERICHOST) != 0) {
+      continue;
+    }
+
+    result = g_strdup (buf);
+  }
+
+  freeifaddrs (addrs);
+
+  return result;
+}

--- a/hwangsae/common.h
+++ b/hwangsae/common.h
@@ -1,0 +1,20 @@
+/**
+ *  Copyright 2019 SK Telecom Co., Ltd.
+ *    Author: Walter Lozano <walter.lozano@collabora.com>
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+#include <glib.h>
+
+gchar           *hwangsae_common_get_local_ip (void);

--- a/hwangsae/dbus/org.hwangsaeul.Hwangsae1.RecorderInterface.xml
+++ b/hwangsae/dbus/org.hwangsaeul.Hwangsae1.RecorderInterface.xml
@@ -51,5 +51,29 @@
       <arg name="records" direction="out" type="a(ssxxx)"/>
     </method>
 
+    <!--
+    Url:
+    @edgeId:          an unique id of edge
+    @fileId:          an unique id of file
+
+    Get the URL of a file
+    -->
+    <method name="Url">
+      <arg name="edgeId" direction="in" type="s"/>
+      <arg name="fileId" direction="in" type="s"/>
+      <arg name="url" direction="out" type="s"/>
+    </method>
+
+    <!--
+    Delete:
+    @edgeId:          an unique id of edge
+    @fileId:          an unique id of file
+
+    Delete a file
+    -->
+    <method name="Delete">
+      <arg name="edgeId" direction="in" type="s"/>
+      <arg name="fileId" direction="in" type="s"/>
+    </method>
   </interface>
 </node>

--- a/hwangsae/meson.build
+++ b/hwangsae/meson.build
@@ -14,6 +14,7 @@ source_h = [
 source_c = [
   'recorder.c',
   'relay.c',
+  'common.c'
 ]
 
 gsettings_schemas = [

--- a/hwangsae/relay.c
+++ b/hwangsae/relay.c
@@ -17,9 +17,8 @@
  */
 
 #include "relay.h"
+#include "common.h"
 
-#include <ifaddrs.h>
-#include <net/if.h>
 #include <srt/srt.h>
 #include <gio/gio.h>
 
@@ -533,52 +532,6 @@ hwangsae_relay_new (void)
 }
 
 static gchar *
-_get_local_ip (void)
-{
-  struct ifaddrs *addrs;
-  struct ifaddrs *it;
-  gchar *result = NULL;
-
-  if (getifaddrs (&addrs) < 0) {
-    return NULL;
-  }
-
-  for (it = addrs; !result && it; it = it->ifa_next) {
-    socklen_t addr_len;
-    char buf[INET6_ADDRSTRLEN + 1];
-
-    /* Ignore interfaces that are down, not running or don't have an IP. We also
-     * want to skip loopbacks. */
-    if ((it->ifa_flags & (IFF_UP | IFF_RUNNING | IFF_LOOPBACK)) !=
-        (IFF_UP | IFF_RUNNING) || it->ifa_addr == NULL) {
-      continue;
-    }
-
-    switch (it->ifa_addr->sa_family) {
-      case AF_INET:
-        addr_len = sizeof (struct sockaddr_in);
-        break;
-      case AF_INET6:
-        addr_len = sizeof (struct sockaddr_in6);
-        break;
-      default:
-        continue;
-    }
-
-    if (getnameinfo (it->ifa_addr, addr_len, buf, sizeof (buf), NULL, 0,
-            NI_NUMERICHOST) != 0) {
-      continue;
-    }
-
-    result = g_strdup (buf);
-  }
-
-  freeifaddrs (addrs);
-
-  return result;
-}
-
-static gchar *
 hwangsae_relay_make_uri (HwangsaeRelay * self, guint port)
 {
   g_autofree gchar *local_ip = NULL;
@@ -587,7 +540,7 @@ hwangsae_relay_make_uri (HwangsaeRelay * self, guint port)
   if (self->external_ip) {
     ip = self->external_ip;
   } else {
-    ip = local_ip = _get_local_ip ();
+    ip = local_ip = hwangsae_common_get_local_ip ();
   }
 
   return g_strdup_printf ("srt://%s:%d", ip, port);


### PR DESCRIPTION
This PR fixes the file_id usage in recorder-agent D-BUS API and adds URL and Delete methods