### PR TITLE
recording-agent: change recording file naming scheme

### DIFF
--- a/agent/recorder-agent.c
+++ b/agent/recorder-agent.c
@@ -46,6 +46,7 @@ struct _HwangsaeRecorderAgent
   HwangsaeHttpServer *hwangsae_http_server;
 
   gboolean is_recording;
+  gint64 recording_id;
 };
 
 /* *INDENT-OFF* */
@@ -120,10 +121,11 @@ hwangsae_recorder_agent_start_recording (HwangsaeRecorderAgent * self,
 
   if (self->is_recording) {
     g_warning ("recording already started");
-    return hwangsae_recorder_get_recording_id (self->recorder);
+    return self->recording_id;
   }
 
   self->is_recording = TRUE;
+  self->recording_id = g_get_real_time ();
 
   hwangsae_recorder_agent_send_rest_api (self, RELAY_METHOD_START_STREAMING,
       edge_id);
@@ -148,7 +150,9 @@ hwangsae_recorder_agent_start_recording (HwangsaeRecorderAgent * self,
 
   g_object_set (self->recorder, "recording-dir", recording_edge_dir, NULL);
 
-  return hwangsae_recorder_start_recording (self->recorder, url);
+  hwangsae_recorder_start_recording (self->recorder, url);
+
+  return self->recording_id;
 }
 
 static void

--- a/agent/recorder-agent.c
+++ b/agent/recorder-agent.c
@@ -118,6 +118,7 @@ hwangsae_recorder_agent_start_recording (HwangsaeRecorderAgent * self,
   g_autofree gchar *streamid = NULL;
   g_autofree gchar *url = NULL;
   g_autofree gchar *recording_edge_dir = NULL;
+  g_autofree gchar *filename_prefix = NULL;
 
   if (self->is_recording) {
     g_warning ("recording already started");
@@ -148,7 +149,11 @@ hwangsae_recorder_agent_start_recording (HwangsaeRecorderAgent * self,
 
   g_debug ("setting recording_dir: %s\n", recording_edge_dir);
 
-  g_object_set (self->recorder, "recording-dir", recording_edge_dir, NULL);
+  filename_prefix = g_strdup_printf ("hwangsae-recording-%ld",
+      self->recording_id);
+
+  g_object_set (self->recorder, "recording-dir", recording_edge_dir,
+      "filename-prefix", filename_prefix, NULL);
 
   hwangsae_recorder_start_recording (self->recorder, url);
 

--- a/hwangsae/recorder.h
+++ b/hwangsae/recorder.h
@@ -52,10 +52,7 @@ void                    hwangsae_recorder_set_max_size_bytes
 guint64                 hwangsae_recorder_get_max_size_bytes
                                                        (HwangsaeRecorder * self);
 
-gint64                  hwangsae_recorder_get_recording_id
-                                                       (HwangsaeRecorder * self);
-
-gint64                  hwangsae_recorder_start_recording
+void                    hwangsae_recorder_start_recording
                                                        (HwangsaeRecorder * self,
                                                         const gchar * uri);
 

--- a/tests/test-recorder.c
+++ b/tests/test-recorder.c
@@ -388,7 +388,6 @@ split_file_created_cb (HwangsaeRecorder * recorder,
 {
   g_debug ("Created file %s", file_path);
 
-  data->filenames = g_slist_append (data->filenames, g_strdup (file_path));
   if (++data->file_created_signal_count == NUM_FILE_SEGMENTS) {
     hwangsae_recorder_stop_recording (recorder);
   }
@@ -400,6 +399,7 @@ split_file_completed_cb (HwangsaeRecorder * recorder,
 {
   g_debug ("Completed file %s", file_path);
 
+  data->filenames = g_slist_append (data->filenames, g_strdup (file_path));
   ++data->file_completed_signal_count;
 }
 

--- a/tools/recorder.c
+++ b/tools/recorder.c
@@ -47,18 +47,11 @@ stream_connected_cb (HwangsaeRecorder * recorder, gpointer unused)
   g_print ("Stream connected\n");
 }
 
-
-static void
-file_created_cb (HwangsaeRecorder * recorder, const gchar * file_path,
-    gpointer unused)
-{
-  g_print ("Recording to file %s\n", file_path);
-}
-
 static void
 file_completed_cb (HwangsaeRecorder * recorder, const gchar * file_path,
     GApplication * app)
 {
+  g_print ("Created recording  %s\n", file_path);
   g_application_release (app);
 }
 
@@ -117,8 +110,6 @@ main (int argc, char *argv[])
   recorder = hwangsae_recorder_new ();
   g_signal_connect (recorder, "stream-connected",
       (GCallback) stream_connected_cb, NULL);
-  g_signal_connect (recorder, "file-created",
-      (GCallback) file_created_cb, NULL);
   g_signal_connect (recorder, "file-completed",
       (GCallback) file_completed_cb, app);
 


### PR DESCRIPTION
The new scheme is

`hwangsae-recorder-{recording_id}-{start_timestamp}-{end_timestamp}.(ts|mp4)`.