### PR TITLE
recorder-agent: fix leaks

### DIFF
--- a/agent/recorder-agent.c
+++ b/agent/recorder-agent.c
@@ -128,6 +128,7 @@ hwangsae_recorder_agent_start_recording (HwangsaeRecorderAgent * self,
   g_autoptr (GError) error = NULL;
   g_autofree gchar *host = g_strdup (self->relay_address);
   guint port = self->relay_stream_port;
+  g_autofree gchar *streamid_tmp = NULL;
   g_autofree gchar *streamid = NULL;
   g_autofree gchar *url = NULL;
   g_autofree gchar *recording_edge_dir = NULL;
@@ -144,8 +145,8 @@ hwangsae_recorder_agent_start_recording (HwangsaeRecorderAgent * self,
   hwangsae_recorder_agent_send_rest_api (self, RELAY_METHOD_START_STREAMING,
       edge_id);
 
-  streamid = g_strdup_printf ("#!::r=%s", edge_id);
-  streamid = g_uri_escape_string (streamid, NULL, FALSE);
+  streamid_tmp = g_strdup_printf ("#!::r=%s", edge_id);
+  streamid = g_uri_escape_string (streamid_tmp, NULL, FALSE);
   url = g_strdup_printf ("srt://%s:%d?streamid=%s", host, port, streamid);
 
   g_debug ("starting to recording stream from %s", url);
@@ -253,7 +254,7 @@ gboolean
     GDBusMethodInvocation * invocation, gchar * arg_id, gpointer user_data) {
   g_autofree gchar *cmd = NULL;
   g_autofree gchar *response = NULL;
-  gchar *record_id = NULL;
+  g_autofree gchar *record_id = NULL;
   gint64 rec_id;
 
   HwangsaeRecorderAgent *self = (HwangsaeRecorderAgent *) user_data;
@@ -521,7 +522,7 @@ hwangsae_recorder_agent_recorder_interface_handle_url
   HwangsaeRecorderAgent *self = (HwangsaeRecorderAgent *) user_data;
   g_autofree gchar *cmd = NULL;
   g_autofree gchar *response = NULL;
-  gchar *url = NULL;
+  g_autofree gchar *url = NULL;
 
   g_debug ("hwangsae_recorder_agent_recorder_interface_handle_url");
 

--- a/hwangsae/recorder.c
+++ b/hwangsae/recorder.c
@@ -265,6 +265,7 @@ hwangsae_recorder_start_recording (HwangsaeRecorder * self, const gchar * uri)
   g_autoptr (GstBus) bus = NULL;
   g_autoptr (GstElement) element = NULL;
   g_autoptr (GstPad) parse_src = NULL;
+  g_autofree gchar *recording_file_tmp = NULL;
   g_autofree gchar *recording_file = NULL;
   g_autofree gchar *pipeline_str = NULL;
   const gchar *mux_name;
@@ -274,9 +275,9 @@ hwangsae_recorder_start_recording (HwangsaeRecorder * self, const gchar * uri)
 
   g_mkdir_with_parents (priv->recording_dir, 0750);
 
-  recording_file = g_build_filename (priv->recording_dir,
+  recording_file_tmp = g_build_filename (priv->recording_dir,
       "%s-%ld-%%05d.tmp", NULL);
-  recording_file = g_strdup_printf (recording_file, priv->filename_prefix,
+  recording_file = g_strdup_printf (recording_file_tmp, priv->filename_prefix,
       g_get_real_time ());
 
   switch (priv->container) {


### PR DESCRIPTION
This patch fixes some leaks I found. There is and additional leak in the `lookup` functions

```
  builder = g_variant_builder_new (G_VARIANT_TYPE ("a(sxxx)"));

  edge_id = get_records (recording_dir, NULL, arg_record_id, arg_from, arg_to,
      builder);

  records = g_variant_new ("a(sxxx)", builder);

  g_variant_builder_unref (builder);

  hwangsae1_dbus_recorder_interface_complete_lookup_by_record (object,
      invocation, edge_id, records);
```

As `records` is of type `a(sxxx)` there is an array of strings and uint that should be freed. Is there a proper way to free these memory without doing a loop?