### PR TITLE
settings: instantiate GSettings with chamge_common_gsettings_new()

### DIFF
--- a/agent/meson.build
+++ b/agent/meson.build
@@ -20,5 +20,5 @@ executable('hwangsae-recorder-agent',
   install: true,
   include_directories: hwangsae_incs,
   c_args: [ hwangsae_agent_c_args, ],
-  dependencies: [ libhwangsae_dbus_dep, libhwangsae_dep, gstreamer_dep,
-                 soup_dep, json_glib_dep],)
+  dependencies: [ libhwangsae_dbus_dep, libhwangsae_dep, chamge_dep,
+                 gstreamer_dep, soup_dep, json_glib_dep],)

--- a/agent/recorder-agent.c
+++ b/agent/recorder-agent.c
@@ -20,6 +20,7 @@
 
 #include "recorder-agent.h"
 #include "http-server.h"
+#include <chamge/chamge.h>
 #include <hwangsae/recorder.h>
 #include <glib/gstdio.h>
 #include <gst/gst.h>
@@ -672,7 +673,7 @@ hwangsae_recorder_agent_init (HwangsaeRecorderAgent * self)
 {
   self->is_recording = FALSE;
 
-  self->settings = g_settings_new (HWANGSAE_RECORDER_SCHEMA_ID);
+  self->settings = chamge_common_gsettings_new (HWANGSAE_RECORDER_SCHEMA_ID);
 
   g_settings_bind (self->settings, "recording-dir", self, "recording-dir",
       G_SETTINGS_BIND_DEFAULT);

--- a/hwangsae/common.c
+++ b/hwangsae/common.c
@@ -15,11 +15,15 @@
  *  limitations under the License.
  *
  */
-#include <gio/gio.h>
+
+#include "common.h"
+
 #include <errno.h>
 #include <ifaddrs.h>
 #include <net/if.h>
 #include <netdb.h>
+#define G_SETTINGS_ENABLE_BACKEND
+#include <gio/gsettingsbackend.h>
 
 gchar *
 hwangsae_common_get_local_ip (void)
@@ -65,4 +69,23 @@ hwangsae_common_get_local_ip (void)
   freeifaddrs (addrs);
 
   return result;
+}
+
+GSettings *
+hwangsae_common_gsettings_new (const gchar * schema_id)
+{
+  if (glib_check_version (2, 60, 5) && getppid () == 1) {
+    /* Workaround GLib bug where keyfile GSettings backend wasn't registered. */
+    g_autoptr (GSettingsBackend) backend = NULL;
+    g_autofree char *filename = NULL;
+
+    filename = g_build_filename (g_get_user_config_dir (), "glib-2.0",
+        "settings", "keyfile", NULL);
+
+    backend = g_keyfile_settings_backend_new (filename, "/", NULL);
+
+    return g_settings_new_with_backend (schema_id, backend);
+  }
+
+  return g_settings_new (schema_id);
 }

--- a/hwangsae/common.h
+++ b/hwangsae/common.h
@@ -15,6 +15,8 @@
  *  limitations under the License.
  *
  */
-#include <glib.h>
+#include <gio/gio.h>
 
-gchar           *hwangsae_common_get_local_ip (void);
+gchar           *hwangsae_common_get_local_ip  (void);
+
+GSettings       *hwangsae_common_gsettings_new (const gchar * schema_id);

--- a/hwangsae/recorder.c
+++ b/hwangsae/recorder.c
@@ -460,7 +460,8 @@ hwangsae_recorder_init (HwangsaeRecorder * self)
   HwangsaeRecorderPrivate *priv = hwangsae_recorder_get_instance_private (self);
   g_autofree gchar *dir = NULL;
 
-  priv->settings = g_settings_new ("org.hwangsaeul.hwangsae.recorder");
+  priv->settings =
+      hwangsae_common_gsettings_new ("org.hwangsaeul.hwangsae.recorder");
 
   dir = g_build_filename (g_get_user_data_dir (),
       "hwangsaeul", "hwangsae", "recordings", NULL);

--- a/hwangsae/relay.c
+++ b/hwangsae/relay.c
@@ -492,7 +492,8 @@ hwangsae_relay_init (HwangsaeRelay * self)
 
   g_mutex_init (&self->lock);
 
-  self->settings = g_settings_new ("org.hwangsaeul.hwangsae.relay");
+  self->settings =
+      hwangsae_common_gsettings_new ("org.hwangsaeul.hwangsae.relay");
 
   g_settings_bind (self->settings, "sink-port", self, "sink-port",
       G_SETTINGS_BIND_DEFAULT);


### PR DESCRIPTION
Works around GSETTINGS_BACKEND=keyfile bug in older GLib.