### PR TITLE
recorder-agent: add recorder_id property

### DIFF
--- a/agent/recorder-agent.c
+++ b/agent/recorder-agent.c
@@ -586,7 +586,7 @@ hwangsae_recorder_agent_set_property (GObject * object, guint property_id,
   switch (property_id) {
     case PROP_RECORDING_DIR:
       g_clear_pointer (&self->recording_dir, g_free);
-      self->recording_dir = g_strdup (g_value_get_string (value));
+      self->recording_dir = g_value_dup_string (value);
       break;
     case PROP_RELAY_ADDRESS:
       g_clear_pointer (&self->relay_address, g_free);

--- a/agent/recorder-agent.c
+++ b/agent/recorder-agent.c
@@ -49,6 +49,7 @@ struct _HwangsaeRecorderAgent
   gchar *relay_address;
   guint relay_api_port;
   guint relay_stream_port;
+  gchar *recorder_id;
 
   gboolean is_recording;
   gint64 recording_id;
@@ -72,6 +73,7 @@ enum
   PROP_RELAY_ADDRESS,
   PROP_RELAY_API_PORT,
   PROP_RELAY_STREAM_PORT,
+  PROP_RECORDER_ID,
   PROP_LAST
 };
 
@@ -145,7 +147,7 @@ hwangsae_recorder_agent_start_recording (HwangsaeRecorderAgent * self,
   hwangsae_recorder_agent_send_rest_api (self, RELAY_METHOD_START_STREAMING,
       edge_id);
 
-  streamid_tmp = g_strdup_printf ("#!::r=%s", edge_id);
+  streamid_tmp = g_strdup_printf ("#!::r=%s,u=%s", edge_id, self->recorder_id);
   streamid = g_uri_escape_string (streamid_tmp, NULL, FALSE);
   url = g_strdup_printf ("srt://%s:%d?streamid=%s", host, port, streamid);
 
@@ -596,6 +598,10 @@ hwangsae_recorder_agent_set_property (GObject * object, guint property_id,
     case PROP_RELAY_STREAM_PORT:
       self->relay_stream_port = g_value_get_uint (value);
       break;
+    case PROP_RECORDER_ID:
+      g_clear_pointer (&self->recorder_id, g_free);
+      self->recorder_id = g_value_dup_string (value);
+      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
   }
@@ -619,6 +625,9 @@ hwangsae_recorder_agent_get_property (GObject * object, guint property_id,
       break;
     case PROP_RELAY_STREAM_PORT:
       g_value_set_uint (value, self->relay_stream_port);
+      break;
+    case PROP_RECORDER_ID:
+      g_value_set_string (value, self->recorder_id);
       break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
@@ -653,6 +662,9 @@ hwangsae_recorder_agent_class_init (HwangsaeRecorderAgentClass * klass)
           "Relay Stream port", 0, G_MAXUINT, 9999,
           G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
+  g_object_class_install_property (gobject_class, PROP_RECORDER_ID,
+      g_param_spec_string ("recorder-id", "Recorder ID",
+          "Recorder ID", "", G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
   gobject_class->dispose = hwangsae_recorder_agent_dispose;
 
   app_class->dbus_register = hwangsae_recorder_agent_dbus_register;
@@ -685,6 +697,18 @@ hwangsae_recorder_agent_init (HwangsaeRecorderAgent * self)
 
   g_settings_bind (self->settings, "relay-stream-port", self,
       "relay-stream-port", G_SETTINGS_BIND_DEFAULT);
+
+  g_settings_bind (self->settings, "recorder-id", self, "recorder-id",
+      G_SETTINGS_BIND_DEFAULT);
+
+  if (!g_strcmp0 (self->recorder_id, "randomized-string")
+      || strnlen (self->recorder_id, 64) == 0) {
+    g_autofree gchar *uid = g_uuid_string_random ();
+    g_autofree gchar *recorder_id =
+        g_compute_checksum_for_string (G_CHECKSUM_SHA256, uid, strnlen (uid,
+            64));
+    g_object_set (self, "recorder-id", recorder_id, NULL);
+  }
 
   self->recorder = hwangsae_recorder_new ();
 

--- a/hwangsae/org.hwangsaeul.hwangsae.gschema.xml
+++ b/hwangsae/org.hwangsaeul.hwangsae.gschema.xml
@@ -54,5 +54,10 @@
         access the recordings via HTTP.
       </description>
     </key>
+    <key name="recorder-id" type="s">
+      <default>"randomized-string"</default>
+      <summary>Recorder ID</summary>
+      <description>Unique identifier for the Recorder Agent</description>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
Please check if this is implementation goes in the right direction. Initial tests shows that Relay doesn't take username into account when the request comes from Recorder, only when request comes from Edge.

Does this make sense?