### PR TITLE
transmuxer: use correct base time for segment

### DIFF
--- a/hwangsae/common.c
+++ b/hwangsae/common.c
@@ -97,7 +97,10 @@ hwangsae_common_parse_times_from_filename (const gchar * filename,
 {
   gboolean result = FALSE;
   gchar **parts = g_strsplit_set (filename, "-.", -1);
+  gchar *endptr;
   guint len = g_strv_length (parts);
+  guint64 start;
+  guint64 end;
 
   if (len < 4) {
     goto out;
@@ -107,11 +110,21 @@ hwangsae_common_parse_times_from_filename (const gchar * filename,
    * /path/to/file/recording-name-starttimeusec-endtimeusec.ts
    */
 
+  start = g_ascii_strtoull (parts[len - 3], &endptr, 10) * GST_USECOND;
+  if (*endptr != '\0') {
+    goto out;
+  }
+
+  end = g_ascii_strtoull (parts[len - 2], &endptr, 10) * GST_USECOND;
+  if (*endptr != '\0') {
+    goto out;
+  }
+
   if (start_time) {
-    *start_time = atol (parts[len - 3]) * GST_USECOND;
+    *start_time = start;
   }
   if (end_time) {
-    *end_time = atol (parts[len - 2]) * GST_USECOND;
+    *end_time = end;
   }
 
   result = TRUE;

--- a/hwangsae/transmuxer.c
+++ b/hwangsae/transmuxer.c
@@ -127,6 +127,7 @@ _bus_watch (GstBus * bus, GstMessage * message, gpointer user_data)
           gst_element_set_state (priv->pipeline, GST_STATE_PLAYING);
         }
       }
+      break;
     }
     default:
       break;

--- a/tests/test-transmuxer.c
+++ b/tests/test-transmuxer.c
@@ -71,6 +71,7 @@ test_corrupted (void)
   g_autoptr (GError) error = NULL;
   g_autofree gchar *output_file = NULL;
   GSList *input_files = NULL;
+  GstClockTimeDiff gap;
 
   input_files = g_slist_append (input_files,
       g_test_build_filename (G_TEST_DIST, "data/test-0-5000000.ts", NULL));
@@ -96,6 +97,11 @@ test_corrupted (void)
   /* Total file duration should be 15 seconds. */
   g_assert_cmpuint (hwangsae_test_get_file_duration (output_file), ==,
       15 * GST_SECOND);
+
+  /* Gap should last 5 seconds ±20ms. */
+  gap = hwangsae_test_get_gap_duration (output_file);
+  g_assert_cmpint (labs (GST_CLOCK_DIFF (gap, 5 * GST_SECOND)), <=,
+      20 * GST_MSECOND);
 
   g_slist_free_full (input_files, g_free);
 

--- a/tests/test-transmuxer.c
+++ b/tests/test-transmuxer.c
@@ -77,7 +77,7 @@ test_corrupted (void)
 
   input_files = g_slist_append (input_files,
       g_test_build_filename (G_TEST_DIST,
-          "data/test-5000000-10000000-corrupted.ts", NULL));
+          "data/test-corrupted-5000000-10000000.ts", NULL));
 
   input_files =
       g_slist_append (input_files, g_test_build_filename (G_TEST_DIST,


### PR DESCRIPTION
Since some input files may be skipped (e.g. because of corrupted contents), _src_probe() can't just use the items in segments list one by one. This change makes sure the base time corresponding to the active pad of the concat element gets picked for segment event.