### PR TITLE
recorder-agent: fix wrong HTTP server base directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,16 @@ build/
 # subprojects
 subprojects/gaeguli/
 subprojects/chamge/
+
+# Debian build
+debian/.debhelper/
+debian/tmp/
+debian/hwangsae-recorder/
+debian/hwangsae-relay/
+debian/hwangsae-tools/
+debian/libhwangsae*/
+debian/*.debhelper
+debian/*.substvars
+debian/files
+debian/substvars
+debian/debhelper-build-stamp

--- a/agent/multi-recorder-agent.c
+++ b/agent/multi-recorder-agent.c
@@ -104,12 +104,6 @@ hwangsae_multi_recorder_agent_start_recording (HwangsaeRecorderAgent *
 
   g_debug ("starting to recording stream from %s", url);
 
-  if (g_str_equal (recording_dir, "")) {
-    g_free (recording_dir);
-    recording_dir = g_build_filename (g_get_user_data_dir (),
-        "hwangsaeul", "hwangsae", "recordings", NULL);
-  }
-
   recording_edge_dir = g_build_filename (recording_dir, edge_id, NULL);
 
   filename_prefix = g_strdup_printf ("hwangsae-recording-%ld",

--- a/agent/simple-recorder-agent.c
+++ b/agent/simple-recorder-agent.c
@@ -78,12 +78,6 @@ hwangsae_simple_recorder_agent_start_recording (HwangsaeRecorderAgent *
 
   g_debug ("starting to recording stream from %s", url);
 
-  if (g_str_equal (recording_dir, "")) {
-    g_free (recording_dir);
-    recording_dir = g_build_filename (g_get_user_data_dir (),
-        "hwangsaeul", "hwangsae", "recordings", NULL);
-  }
-
   recording_edge_dir = g_build_filename (recording_dir, edge_id, NULL);
 
   filename_prefix = g_strdup_printf ("hwangsae-recording-%ld",


### PR DESCRIPTION
Make sure the base dir of our HTTP server is always synchronized with
agent's recording directory. When the default location in XDG_DATA_HOME
was in use, the setting was *not* propagated to the server and so all
file search requests coming through DBus failed.