### PR TITLE
relay: remove internal gsettings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
                   gstreamer1.0-plugins-bad \
                   gstreamer1.0-plugins-ugly \
                   libsrt-dev \
+                  libsoup2.4-dev \
                   libjson-glib-dev \
                   meson ninja-build 
       - name: Compile

--- a/hwangsae/relay.h
+++ b/hwangsae/relay.h
@@ -40,12 +40,17 @@ G_DECLARE_FINAL_TYPE            (HwangsaeRelay, hwangsae_relay, HWANGSAE, RELAY,
 
 /**
  * hwangsae_relay_new:
+ * @external_ip: an external ip address
+ * @sink_port: an inbound network port
+ * @source_port: an outbound network port
  *
  * Creates a new HwangsaeRelay object
  *
  * Returns: the newly created object
  */
-HwangsaeRelay          *hwangsae_relay_new              (void);
+HwangsaeRelay          *hwangsae_relay_new              (const gchar   *external_ip,
+                                                         guint          sink_port,
+                                                         guint          source_port);
 
 /**
  * hwangsae_relay_get_sink_uri:

--- a/tests/test-relay.c
+++ b/tests/test-relay.c
@@ -31,7 +31,7 @@ static void
 test_relay_instance (void)
 {
   guint sink_port, source_port;
-  g_autoptr (HwangsaeRelay) relay = hwangsae_relay_new ();
+  g_autoptr (HwangsaeRelay) relay = hwangsae_relay_new ("", 8888, 9999);
 
   g_assert_nonnull (relay);
 
@@ -46,7 +46,8 @@ static void
 test_external_ip (void)
 {
   static const gchar *EXTERNAL_IP = "10.1.2.3";
-  g_autoptr (HwangsaeRelay) relay = hwangsae_relay_new ();
+  g_autoptr (HwangsaeRelay) relay =
+      hwangsae_relay_new (EXTERNAL_IP, 8888, 9999);
   g_autofree gchar *sink_uri = NULL;
   g_autofree gchar *source_uri = NULL;
   guint sink_port, source_port;
@@ -139,7 +140,7 @@ static void
 test_1_to_n (void)
 {
   g_autoptr (HwangsaeTestStreamer) streamer = hwangsae_test_streamer_new ();
-  g_autoptr (HwangsaeRelay) relay = hwangsae_relay_new ();
+  g_autoptr (HwangsaeRelay) relay = hwangsae_relay_new (NULL, 8888, 9999);
   g_autofree gchar *source_uri = NULL;
   RelayTestData data1 = { 0 };
   RelayTestData data2 = { 0 };
@@ -182,7 +183,7 @@ test_m_to_n (void)
 {
   g_autoptr (HwangsaeTestStreamer) streamer1 = hwangsae_test_streamer_new ();
   g_autoptr (HwangsaeTestStreamer) streamer2 = hwangsae_test_streamer_new ();
-  g_autoptr (HwangsaeRelay) relay = hwangsae_relay_new ();
+  g_autoptr (HwangsaeRelay) relay = hwangsae_relay_new (NULL, 8888, 9999);
   g_autofree gchar *source_uri1 = NULL;
   g_autofree gchar *source_uri2 = NULL;
   RelayTestData data1 = { 0 };


### PR DESCRIPTION
This commit drops gsettings dependency from hwangsae-relay.
Instead, the relay will take construct parameters.