### PR TITLE
relay: slave mode

### DIFF
--- a/hwangsae/common.h
+++ b/hwangsae/common.h
@@ -25,3 +25,7 @@ gboolean         hwangsae_common_parse_times_from_filename
                                                (const gchar *filename,
                                                 guint64     *start_time,
                                                 guint64     *end_time);
+
+gboolean         hwangsae_common_parse_srt_uri (const gchar  *uri,
+                                                gchar       **host,
+                                                guint        *port);

--- a/hwangsae/relay.c
+++ b/hwangsae/relay.c
@@ -531,7 +531,7 @@ hwangsae_relay_accept_source (HwangsaeRelay * self, SRTSOCKET sock,
     }
 
     g_signal_emit (self, signals[SIG_AUTHENTICATE], 0,
-        HWANGSAE_CALLER_DIRECTION_SINK, addr, username, resource,
+        HWANGSAE_CALLER_DIRECTION_SRC, addr, username, resource,
         &authenticated);
 
     if (!authenticated) {

--- a/hwangsae/relay.c
+++ b/hwangsae/relay.c
@@ -130,8 +130,6 @@ static SrtParam srt_params[] = {
   {NULL, -1, -1},
 };
 
-static void hwangsae_relay_constructed (GObject * object);
-
 static void
 hwangsae_relay_remove_sink (HwangsaeRelay * self, SinkConnection * sink)
 {
@@ -312,7 +310,6 @@ hwangsae_relay_class_init (HwangsaeRelayClass * klass)
 {
   GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
 
-  gobject_class->constructed = hwangsae_relay_constructed;
   gobject_class->set_property = hwangsae_relay_set_property;
   gobject_class->get_property = hwangsae_relay_get_property;
   gobject_class->finalize = hwangsae_relay_finalize;
@@ -320,12 +317,12 @@ hwangsae_relay_class_init (HwangsaeRelayClass * klass)
   g_object_class_install_property (gobject_class, PROP_SINK_PORT,
       g_param_spec_uint ("sink-port", "SRT Binding port (from) ",
           "SRT Binding port (from)", 0, G_MAXUINT, 8888,
-          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (gobject_class, PROP_SOURCE_PORT,
       g_param_spec_uint ("source-port", "SRT Binding port (to) ",
           "SRT Binding port (to)", 0, G_MAXUINT, 9999,
-          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS));
+          G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
   g_object_class_install_property (gobject_class, PROP_EXTERNAL_IP,
       g_param_spec_string ("external-ip", "Relay external IP",
@@ -693,11 +690,9 @@ hwangsae_relay_init (HwangsaeRelay * self)
   self->username_sink_map = g_hash_table_new (g_str_hash, g_str_equal);
 }
 
-static void
-hwangsae_relay_constructed (GObject * object)
+void
+hwangsae_relay_start (HwangsaeRelay * self)
 {
-  HwangsaeRelay *self = HWANGSAE_RELAY (object);
-
   LOCK_RELAY;
 
   self->run_relay_thread = TRUE;

--- a/hwangsae/relay.h
+++ b/hwangsae/relay.h
@@ -53,6 +53,15 @@ HwangsaeRelay          *hwangsae_relay_new              (const gchar   *external
                                                          guint          source_port);
 
 /**
+ * hwangsae_relay_start:
+ * @relay: a HwangsaeRelay object
+ *
+ * Makes the relay start listening on sink and source ports and forwarding
+ * the streams.
+ */
+void                    hwangsae_relay_start            (HwangsaeRelay *relay);
+
+/**
  * hwangsae_relay_get_sink_uri:
  * @relay: a pointer to a HwangsaeRelay object
  *

--- a/tests/test-relay.c
+++ b/tests/test-relay.c
@@ -155,6 +155,8 @@ test_1_to_n (void)
 
   hwangsae_test_streamer_set_uri (streamer,
       hwangsae_relay_get_sink_uri (relay));
+
+  hwangsae_relay_start (relay);
   hwangsae_test_streamer_start (streamer);
 
   /* Connect and validate two receivers. */
@@ -208,6 +210,7 @@ test_m_to_n (void)
   g_object_set (streamer2, "resolution", data2.resolution, NULL);
   data2.source_uri = source_uri2 = build_source_uri (streamer2, relay, NULL);
 
+  hwangsae_relay_start (relay);
   hwangsae_test_streamer_start (streamer1);
   hwangsae_test_streamer_start (streamer2);
 
@@ -257,6 +260,7 @@ test_reject_sink (void)
   g_signal_connect (relay, "caller-rejected", (GCallback) _on_sink_rejected,
       loop);
 
+  hwangsae_relay_start (relay);
   hwangsae_test_streamer_start (streamer);
 
   g_main_loop_run (loop);
@@ -293,6 +297,8 @@ test_reject_source (void)
 
   g_signal_connect (relay, "caller-rejected", (GCallback) _on_source_rejected,
       loop);
+
+  hwangsae_relay_start (relay);
 
   receiver = gst_parse_launch ("srtsrc uri=srt://127.0.0.1:9999?mode=caller ! "
       "fakesink", &error);
@@ -390,6 +396,8 @@ test_authentication (void)
   g_signal_connect (relay, "authenticate", (GCallback) _authenticate, &data);
 
   hwangsae_test_streamer_set_uri (stream, hwangsae_relay_get_sink_uri (relay));
+
+  hwangsae_relay_start (relay);
   hwangsae_test_streamer_start (stream);
 
   while (!data.sink_rejected) {
@@ -459,6 +467,8 @@ test_no_auth (void)
       build_source_uri (stream1, relay, NULL);
 
   g_object_set (relay, "authentication", FALSE, NULL);
+
+  hwangsae_relay_start (relay);
 
   /* Connect first streamer. */
 


### PR DESCRIPTION
Setting "master-uri" and "master-username" on a HwangsaeRelay will turn
it into a slave relay that requests sinks for its source connections
from the designated master URI and for that purpose authenticates with
"master-username".

