### PR TITLE
relay: improve detection of closed source sockets

### DIFF
--- a/hwangsae/relay.c
+++ b/hwangsae/relay.c
@@ -786,15 +786,15 @@ _relay_main (gpointer data)
 
                 it = it->next;
 
+                if (srt_getsockstate (source_socket) > SRTS_CONNECTED) {
+                  _sink_connection_remove_source (sink, source_socket);
+                  continue;
+                }
+
                 if (srt_send (source_socket, buf, recv) < 0) {
-                  gint error = srt_getlasterror (NULL);
-                  if (error == SRT_ECONNLOST) {
-                    _sink_connection_remove_source (sink, source_socket);
-                  } else {
-                    hwangsae_relay_emit_io_error_locked (self, source_socket,
-                        HWANGSAE_RELAY_ERROR_WRITE, "srt_send failed: %s",
-                        srt_strerror (error, 0));
-                  }
+                  hwangsae_relay_emit_io_error_locked (self, source_socket,
+                      HWANGSAE_RELAY_ERROR_WRITE, "srt_send failed: %s",
+                      srt_strerror (srt_getlasterror (NULL), 0));
                 }
               }
             } else if (recv < 0) {

--- a/hwangsae/relay.c
+++ b/hwangsae/relay.c
@@ -795,6 +795,7 @@ _relay_main (gpointer data)
                   hwangsae_relay_emit_io_error_locked (self, source_socket,
                       HWANGSAE_RELAY_ERROR_WRITE, "srt_send failed: %s",
                       srt_strerror (srt_getlasterror (NULL), 0));
+                  _sink_connection_remove_source (sink, source_socket);
                 }
               }
             } else if (recv < 0) {


### PR DESCRIPTION
Check the state of a source socket before writing into it. Allows
quicker detection of disconnected sockets compared to waiting for
SRT_ECONNLOST returned from srt_send. It also turns out a closed socket
may error out with different return codes, so the previous detection
method wasn't completely reliable.

