### PR TITLE
Fix srt option

### DIFF
--- a/hwangsae/relay.c
+++ b/hwangsae/relay.c
@@ -153,7 +153,6 @@ typedef struct
 } SrtParam;
 
 static SrtParam srt_params[] = {
-  {"SRTO_LINGER", SRTO_LINGER, 0},
   {"SRTO_TSBPMODE", SRTO_TSBPDMODE, 1}, /* Timestamp-based Packet Delivery */
   {"SRTO_RENDEZVOUS", SRTO_RENDEZVOUS, 0},      /* 0: not for rendezvous */
   {"SRTO_SNDBUFLEN", SRTO_SNDBUF, 2 * 0xb80000},


### PR DESCRIPTION
SRT(>= 1.4.2) checks when SRT options are able to be set. In the previous version, it just skipped and ignored, but after the specific version, it aborts running.