### PR TITLE
relay: accept receive buffer size suggestion from STREAMID

### DIFF
--- a/hwangsae/relay.c
+++ b/hwangsae/relay.c
@@ -319,7 +319,7 @@ _srt_open_listen_sock (guint port, gint latency)
     goto failed;
   }
 
-  listen_sock = srt_socket (AF_INET, SOCK_DGRAM, 0);
+  listen_sock = srt_create_socket ();
 
   if (srt_setsockflag (listen_sock, SRTO_LATENCY, &latency, sizeof (gint))) {
     g_error ("Failed to set SRT Latency: %s", srt_getlasterror_str ());
@@ -370,7 +370,7 @@ hwangsae_relay_open_master_sock (HwangsaeRelay * self, const gchar * resource)
     goto failed;
   }
 
-  master_sock = srt_socket (AF_INET, SOCK_DGRAM, 0);
+  master_sock = srt_create_socket ();
   _apply_socket_options (master_sock);
 
   streamid = _make_stream_id (self->master_username, resource);


### PR DESCRIPTION
Recognize 'h8l_bufsize' key that GaeguliTarget adds to STREAMID and set SRTO_RCVBUF accordingly.

Requires https://github.com/hwangsaeul/gaeguli/pull/118
Requires https://github.com/hwangsaeul/gst-plugins-bad/pull/8
Requires https://github.com/hwangsaeul/libsrt/pull/1

Turns out changing `SRTO_RCVBUF` on relay's end **does not work** with upstream libsrt because the client socket passed to the listen callback is already in bound state, which disallows modifying any 'pre' options. Moving opening of the client socket after the listen callback in https://github.com/hwangsaeul/libsrt/pull/1 makes the buffer size change possible, but I can't tell if my patch might have some unwanted side effects. We should bring this up with upstream and check their opinion.